### PR TITLE
Printers errors

### DIFF
--- a/6kyu/3-Printers_errors/description.md
+++ b/6kyu/3-Printers_errors/description.md
@@ -1,0 +1,16 @@
+In a factory a printer prints labels for boxes. For one kind of boxes the printer has to use colors which, for the sake of simplicity, are named with letters from a to m.
+
+The colors used by the printer are recorded in a control string. For example a "good" control string would be aaabbbbhaijjjm meaning that the printer used three times color a, four times color b, one time color h then one time color a...
+
+Sometimes there are problems: lack of colors, technical malfunction and a "bad" control string is produced e.g. aaaxbbbbyyhwawiwjjjwwm with letters not from a to m.
+
+You have to write a function printer_error which given a string will return the error rate of the printer as a string representing a rational whose numerator is the number of errors and the denominator the length of the control string. Don't reduce this fraction to a simpler expression.
+
+The string has a length greater or equal to one and contains only letters from ato z.
+
+Examples:
+s="aaabbbbhaijjjm"
+printer_error(s) => "0/14"
+
+s="aaaxbbbbyyhwawiwjjjwwm"
+printer_error(s) => "8/22"

--- a/6kyu/3-Printers_errors/printers_errors.rb
+++ b/6kyu/3-Printers_errors/printers_errors.rb
@@ -1,0 +1,9 @@
+def printer_error(string)
+  # nbr_of_errors= string.chars.reject { |letter| letter <= 'm'}.length
+  # error_rate = "#{nbr_of_errors}/#{string.length}"
+  
+  "#{string.count('n-z')}/#{string.length}"
+end
+
+s="aaabbbbhaijjjm"
+puts printer_error(s)


### PR DESCRIPTION
Kata solved, use string method available instead of converting the string into an array. Easier and faster