### PR TITLE
6kyu find parity outlier

### DIFF
--- a/6kyu/5-Find_parity_outlier/description.md
+++ b/6kyu/5-Find_parity_outlier/description.md
@@ -1,0 +1,7 @@
+Description:
+You are given an array (which will have a length of at least 3, but could be very large) containing integers. The array is either entirely comprised of odd integers or entirely comprised of even integers except for a single integer N. Write a method that takes the array as an argument and returns this "outlier" N.
+
+Examples
+[2, 4, 0, 100, 4, 11, 2602, 36] -->  11 (the only odd number)
+
+[160, 3, 1719, 19, 11, 13, -21] --> 160 (the only even number)

--- a/6kyu/5-Find_parity_outlier/find_parity_outlier.rb
+++ b/6kyu/5-Find_parity_outlier/find_parity_outlier.rb
@@ -1,0 +1,22 @@
+def find_outlier(integers)
+  # déterminer si la série est paire ou impaire
+  p first_is_even = integers[0].even?
+
+  # déterminer si parmis les 2 premiers nombres, il y a l'intru
+  if integers[1].even? != first_is_even
+    return integers[2].even? == first_is_even ? integers[1] : integers [0]
+  end
+
+  # on rebalaye le tableau jusqu'à trouver l'intru
+  integers.each do |number|
+    return number if number.even? != first_is_even
+  end
+end
+
+input = [2, 4, 0, 100, 4, 11, 2602, 36]
+output = 11
+
+puts find_outlier(input)
+
+# Solution en une ligne
+# integers.partition(&:odd?).find(&:one?).first


### PR DESCRIPTION
Solution in one line:

integers.partition(&:odd?).find(&:one?).first

1. integers.partition(&:odd?)

partition divise le tableau en 2 sous-tableaux selon une condition
&:odd? est un raccourci pour { |x| x.odd? }
Résultat : [[nombres_impairs], [nombres_pairs]]

2. .find(&:one?)

find cherche le premier élément qui satisfait la condition
&:one? est un raccourci pour { |array| array.one? }
one? renvoie true si le tableau contient exactement 1 élément
Résultat : le sous-tableau qui contient un seul élément (l'intrus)